### PR TITLE
ENGPROD-10235: Migrate to Red Hat Hardened Images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Container Image Tests
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test container image
+        run: bash test.sh crc-caddy-plugin:ci-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1785791459 AS build
+FROM registry.access.redhat.com/hi/go:1.26.5-builder@sha256:b163b5484b7b776b285d851414039ed21fc358f4249ecb2901e0f1ba2db2e9b6 AS build
 
 WORKDIR /opt/app-root/src
 
@@ -14,7 +14,7 @@ COPY caddy/build.sh .
 
 RUN bash build.sh
 
-FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi@sha256:aa3bd9e7ae5a183a46fab829aa3eda1ab3fa8ac7f6b2291dee14e48c1ec8c74c
+FROM registry.access.redhat.com/hi/caddy:latest@sha256:f4e737d9b4360c468d0b4b94b2d9e61e23f0c00317d2949eb8665b3a7fa8b63e
 
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY candlepin-ca.pem /cas/ca.pem

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -24,7 +24,6 @@ docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOK
 docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}-PR" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}-PR"
 
-# bypass Jenkins junit checks for now, we have no tests running...
 mkdir -p $WORKSPACE/artifacts
 cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
 <testsuite tests="1">

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+SKIP_BUILD=false
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-build) SKIP_BUILD=true; shift ;;
+        *) IMAGE_NAME="$1"; shift ;;
+    esac
+done
+
+IMAGE_NAME="${IMAGE_NAME:-crc-caddy-plugin:test}"
+PASS=0
+FAIL=0
+
+run_test() {
+    local name="$1"
+    shift
+    echo -n "  $name ... "
+    if output=$("$@" 2>&1); then
+        echo "PASS"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL"
+        echo "    Output: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+if [[ "$SKIP_BUILD" == "false" ]]; then
+    echo "Building image as $IMAGE_NAME ..."
+    $CONTAINER_ENGINE build -t "$IMAGE_NAME" . >/dev/null 2>&1
+    echo "Build successful."
+    echo ""
+fi
+
+echo "Running tests against $IMAGE_NAME ..."
+echo ""
+
+echo "[Image structure]"
+run_test "caddy binary exists" \
+    $CONTAINER_ENGINE run --rm "$IMAGE_NAME" caddy version
+
+run_test "crc-caddy-plugin is compiled in" \
+    bash -c "$CONTAINER_ENGINE run --rm '$IMAGE_NAME' caddy build-info 2>&1 | grep -q 'crc-caddy-plugin'"
+
+run_test "crcauth module is registered" \
+    bash -c "$CONTAINER_ENGINE run --rm '$IMAGE_NAME' caddy list-modules 2>&1 | grep -q 'http.handlers.crcauth'"
+
+echo ""
+echo "[Configuration]"
+run_test "Caddyfile parses successfully" \
+    bash -c "$CONTAINER_ENGINE run --rm -e CADDY_BOP_URL=http://localhost:8080 -e CADDY_WHITELIST='/api/test*' -e CADDY_PORT=8000 '$IMAGE_NAME' caddy adapt --config /etc/caddy/Caddyfile 2>/dev/null | head -1 | grep -q 'apps'"
+
+run_test "crcauth handler is in adapted config" \
+    bash -c "$CONTAINER_ENGINE run --rm -e CADDY_BOP_URL=http://localhost:8080 -e CADDY_WHITELIST='/api/test*' -e CADDY_PORT=8000 '$IMAGE_NAME' caddy adapt --config /etc/caddy/Caddyfile 2>/dev/null | head -1 | grep -q '\"handler\":\"crcauth\"'"
+
+echo ""
+echo "[Security]"
+run_test "runs as non-root user" \
+    bash -c "[[ \$($CONTAINER_ENGINE inspect '$IMAGE_NAME' --format '{{.Config.User}}') != '' && \$($CONTAINER_ENGINE inspect '$IMAGE_NAME' --format '{{.Config.User}}') != 'root' && \$($CONTAINER_ENGINE inspect '$IMAGE_NAME' --format '{{.Config.User}}') != '0' ]]"
+
+run_test "no shell available (distroless)" \
+    bash -c "! $CONTAINER_ENGINE run --rm --entrypoint='' '$IMAGE_NAME' sh -c 'echo vulnerable' 2>/dev/null"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Migrates both Dockerfile base images from UBI go-toolset and caddy-ubi to Red Hat Hardened Images (`registry.access.redhat.com/hi/`), pinned by sha256 digest. Adds a `test.sh` script that validates the built container image (binary presence, plugin compilation, config parsing, non-root user, distroless runtime) and a GitHub Actions workflow to run those tests on PRs and pushes to master.

- **Dockerfile**: Builder stage now uses `hi/go:1.26.5-builder`, runtime stage uses `hi/caddy` — both pinned by digest
- **test.sh**: 7 container image tests covering structure, configuration, and security properties
- **.github/workflows/test.yml**: CI workflow that builds and tests the image on every PR and merge to master
- **pr_check.sh**: Removed stale comment about bypassing tests

Ref: [ENGPROD-10235](https://redhat.atlassian.net/browse/ENGPROD-10235)

[ENGPROD-10235]: https://redhat.atlassian.net/browse/ENGPROD-10235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ